### PR TITLE
winegstreamer: Map big-endian audio formats to their little-endian

### DIFF
--- a/patches/protonprep-valve-staging.sh
+++ b/patches/protonprep-valve-staging.sh
@@ -474,6 +474,9 @@ apply_all_in_dir() {
     echo "WINE: -WINE-GST- 0060-treewide-Fix-some-variable-errors-with-Werror.patch"
     apply_patch "../patches/wine-gst/0060-treewide-Fix-some-variable-errors-with-Werror.patch"
 
+    echo "WINE: -WINE-GST- 0061-winegstreamer-Map-big-endian-audio-formats-to-litt.patch"
+    apply_patch "../patches/wine-gst/0061-winegstreamer-Map-big-endian-audio-formats-to-litt.patch"
+
 ### END WINE-GST PROTON RTSP SECTION ###
 
 ### (2-7) PROTON-GE ADDITIONAL CUSTOM PATCHES ###

--- a/patches/wine-gst/0061-winegstreamer-Map-big-endian-audio-formats-to-litt.patch
+++ b/patches/wine-gst/0061-winegstreamer-Map-big-endian-audio-formats-to-litt.patch
@@ -1,0 +1,46 @@
+From 68605c8e1aeaaa9951e61166320dd595de3a44f1 Mon Sep 17 00:00:00 2001
+From: kazu0617 <kazu0617@protonmail.com>
+Date: Sun, 12 Apr 2026 17:37:26 +0900
+Subject: [PATCH] winegstreamer: Map big-endian audio formats to their
+ little-endian equivalents.
+
+GStreamer sources such as rtpL16depay output audio/x-raw with BE formats
+(e.g. S16BE), which wg_audio_format_from_gst() does not handle, causing
+the stream to be rejected as WG_AUDIO_FORMAT_UNKNOWN.
+
+Add fallthrough cases so each BE format maps to its LE counterpart.
+stream_create_post_processing_elements() already inserts an audioconvert
+element for all audio/x-raw streams; with a valid LE format now requested
+downstream, audioconvert detects the endianness mismatch via caps
+negotiation and performs the byte-swap automatically.
+---
+ dlls/winegstreamer/wg_format.c | 5 +++++
+ 1 file changed, 5 insertions(+)
+
+diff --git a/dlls/winegstreamer/wg_format.c b/dlls/winegstreamer/wg_format.c
+index e6fc0f7b351..76b4863902e 100644
+--- a/dlls/winegstreamer/wg_format.c
++++ b/dlls/winegstreamer/wg_format.c
+@@ -47,14 +47,19 @@ static enum wg_audio_format wg_audio_format_from_gst(GstAudioFormat format)
+         case GST_AUDIO_FORMAT_U8:
+             return WG_AUDIO_FORMAT_U8;
+         case GST_AUDIO_FORMAT_S16LE:
++        case GST_AUDIO_FORMAT_S16BE:
+             return WG_AUDIO_FORMAT_S16LE;
+         case GST_AUDIO_FORMAT_S24LE:
++        case GST_AUDIO_FORMAT_S24BE:
+             return WG_AUDIO_FORMAT_S24LE;
+         case GST_AUDIO_FORMAT_S32LE:
++        case GST_AUDIO_FORMAT_S32BE:
+             return WG_AUDIO_FORMAT_S32LE;
+         case GST_AUDIO_FORMAT_F32LE:
++        case GST_AUDIO_FORMAT_F32BE:
+             return WG_AUDIO_FORMAT_F32LE;
+         case GST_AUDIO_FORMAT_F64LE:
++        case GST_AUDIO_FORMAT_F64BE:
+             return WG_AUDIO_FORMAT_F64LE;
+         default:
+             return WG_AUDIO_FORMAT_UNKNOWN;
+-- 
+2.53.0
+


### PR DESCRIPTION
## Description

A friend reported that RTSP audio streams weren't playing back under Wine. Digging into it, the issue turned out to be endianness: some RTSP sources deliver audio in PCM L16 format, and per [RFC 3551 Section 4.3](https://www.rfc-editor.org/rfc/rfc3551#section-4.3), multi-octet sample-based audio in RTP is transmitted in network byte order (big-endian). GStreamer's rtpL16depay outputs this as audio/x-raw, format=S16BE, but wg_audio_format_from_gst() only handles little-endian variants and returns WG_AUDIO_FORMAT_UNKNOWN, so the stream gets rejected before audioconvert ever runs.

This patch adds fallthrough cases mapping each BE format to its LE equivalent:

- `GST_AUDIO_FORMAT_S16BE` → `WG_AUDIO_FORMAT_S16LE`
- `GST_AUDIO_FORMAT_S24BE` → `WG_AUDIO_FORMAT_S24LE`
- `GST_AUDIO_FORMAT_S32BE` → `WG_AUDIO_FORMAT_S32LE`
- `GST_AUDIO_FORMAT_F32BE` → `WG_AUDIO_FORMAT_F32LE`
- `GST_AUDIO_FORMAT_F64BE` → `WG_AUDIO_FORMAT_F64LE`

`wg_format_to_caps_audio()` requests LE output as before, so the existing `audioconvert` element — which `stream_create_post_processing_elements()` always inserts for `audio/x-raw` streams — detects the endianness mismatch via caps negotiation and performs the byte-swap automatically.

No enum changes are needed: `WAVEFORMATEX` is inherently little-endian, so there's no reason to track BE formats on the Wine side.

## Testing

Reproducible with [mediamtx](https://github.com/bluenviron/mediamtx) as the RTSP server and ffmpeg as the publisher.

**Server:** start mediamtx with default config, then publish a PCM L16 stream:

```
ffmpeg -re -i <filename> -map 0:a -ar 48000 -sample_fmt s16 -c:a pcm_s16be -ac 2 -f rtsp -rtsp_transport tcp -fflags nobuffer+flush_packets -buffer_size 0 -pkt_size 1300 rtsp://localhost:8554/live
```

**Client:** open `rtspt://localhost:8554/live` in VRChat; rtspt denotes RTSP over TCP. Without this patch, `wg_format_from_caps: Unhandled caps` appears in the log and audio playback fails. With the patch, playback works.

> Note: This is unrelated to this patch, but a race condition may occur when stopping RTSP playback, and is more likely to trigger with PCM audio sources. When testing, it is recommended to pause before stopping to avoid this.

## Screenshot:

### Current: 

https://github.com/user-attachments/assets/10826768-3bb8-4442-93d2-9a99c0fb085c

### Patched: 

https://github.com/user-attachments/assets/ead7aa6e-3231-49c3-afd8-88e115c8e06b

> Song: waera - harinezumi
> Music provided by NoCopyrightSounds
> Free Download/Stream: http://ncs.io/harinezumi
> Watch: http://ncs.lnk.to/harinezumiAT/youtube

> Note: This repository has no prior PRs or documented branching policy. I've targeted rtsp/10-33 as the base branch since it's the most recent active branch — please let me know if a different target is appropriate.